### PR TITLE
feat(rules): enforce element mode over syntax mode for JSX fragments

### DIFF
--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -1,6 +1,7 @@
 module.exports = {
   'react/destructuring-assignment': 'off',
   'react/jsx-filename-extension': 'off',
+  'react/jsx-fragments': ['error', 'element'],
   'react/jsx-no-target-blank': 'error',
   'react/jsx-props-no-spreading': 'off',
   'react/self-closing-comp': 'off',


### PR DESCRIPTION
This requires using <React.Fragment></React.Fragment> instead of <></>. The latter can cause
(and has caused) problems in certain scenarios, where the former is always fine.

BREAKING CHANGE: Shorthand JSX fragment syntax is no longer allowed. Replace `<></>` with
`<React.Fragment></React.Fragment>`.