### PR TITLE
feat(jest): add eslint-plugin-jest-dom to plugin:wkovacs64/jest

### DIFF
--- a/lib/config/jest.js
+++ b/lib/config/jest.js
@@ -1,9 +1,11 @@
+const merge = require('merge');
+
 module.exports = {
   env: {
     'jest/globals': true,
   },
 
-  plugins: ['jest'],
+  plugins: ['jest', 'jest-dom'],
 
-  rules: require('./rules/jest'),
+  rules: merge(require('./rules/jest'), require('./rules/jest-dom')),
 };

--- a/lib/config/rules/jest-dom.js
+++ b/lib/config/rules/jest-dom.js
@@ -1,0 +1,9 @@
+module.exports = {
+  'jest-dom/prefer-checked': 'error',
+  'jest-dom/prefer-empty': 'error',
+  'jest-dom/prefer-enabled-disabled': 'error',
+  'jest-dom/prefer-focus': 'error',
+  'jest-dom/prefer-required': 'error',
+  'jest-dom/prefer-to-have-attribute': 'error',
+  'jest-dom/prefer-to-have-text-content': 'error',
+};

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^23.8.2",
+    "eslint-plugin-jest-dom": "^2.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,6 +2197,13 @@ eslint-plugin-import@^2.20.2:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-jest-dom@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-2.1.0.tgz#02a4b84d53f2d39e9a4ede9429a8aeaa4503eb73"
+  integrity sha512-J9H75qqPro0TA5AQcEJtZmxG4Go0KYjZYXAiAmvQsNUOIP1EzCF6BTJSkB/7Sw8wmzgLwNSvhMUDXqDfHa1HqA==
+  dependencies:
+    requireindex "~1.2.0"
+
 eslint-plugin-jest@^23.8.2:
   version "23.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz#6f28b41c67ef635f803ebd9e168f6b73858eb8d4"
@@ -5858,6 +5865,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
BREAKING CHANGE: Current `@testing-library/jest-dom` usage may need updated to satisfy the
new rules introduced in this version. Everything should be fixable, so the upgrade path is
simply running `eslint --fix`.