### PR TITLE
feat(react): add testing-library plugin to plugin:wkovacs64/react

### DIFF
--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -7,11 +7,14 @@ module.exports = {
     browser: true,
   },
 
+  plugins: ['testing-library'],
+
   rules: merge(
     require('./rules/eslint'),
     require('./rules/import'),
     require('./rules/jsx-a11y'),
     require('./rules/react-hooks'),
     require('./rules/react'),
+    require('./rules/testing-library'),
   ),
 };

--- a/lib/config/rules/testing-library.js
+++ b/lib/config/rules/testing-library.js
@@ -1,0 +1,15 @@
+module.exports = {
+  'testing-library/await-async-query': 'error',
+  'testing-library/await-async-utils': 'error',
+  // 'testing-library/await-fire-event': 'error', // Vue
+  'testing-library/consistent-data-testid': 'off',
+  'testing-library/no-await-sync-query': 'error',
+  'testing-library/no-debug': 'off',
+  'testing-library/no-dom-import': ['error', 'react'],
+  'testing-library/no-manual-cleanup': 'error',
+  'testing-library/no-wait-for-empty-callback': 'error',
+  'testing-library/prefer-explicit-assert': 'error',
+  'testing-library/prefer-presence-queries': 'error',
+  'testing-library/prefer-screen-queries': 'error',
+  'testing-library/prefer-wait-for': 'error',
+};

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.0",
+    "eslint-plugin-testing-library": "^3.1.2",
     "merge": "^1.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,6 +522,16 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/experimental-utils@^2.29.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz#a9ec514bf7fd5e5e82bc10dcb6a86d58baae9508"
+  integrity sha512-MI6IWkutLYQYTQgZ48IVnRXmLR/0Q6oAyJgiOror74arUMh7EWjJkADfirZhRsUMHeLJ85U2iySDwHTSnNi9vA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.31.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.5.0.tgz#383a97ded9a7940e5053449f6d73995e782b8fb1"
@@ -545,6 +555,19 @@
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.29.0.tgz#1be6612bb02fc37ac9f466521c1459a4744e8d3a"
   integrity sha512-3YGbtnWy4az16Egy5Fj5CckkVlpIh0MADtAQza+jiMADRSKkjdpzZp/5WuvwK/Qib3Z0HtzrDFeWanS99dNhnA==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz#ac536c2d46672aa1f27ba0ec2140d53670635cfd"
+  integrity sha512-vxW149bXFXXuBrAak0eKHOzbcu9cvi6iNcJDzEtOkRwGHxJG15chiAQAwhLOsk+86p9GTr/TziYvw+H9kMaIgA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -2248,6 +2271,13 @@ eslint-plugin-react@^7.19.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
+
+eslint-plugin-testing-library@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.1.2.tgz#7d67ddc1b7d60af04c02bfe81ca5a96352fd125f"
+  integrity sha512-Xuty2MvgA3vg0dutUwTSeUkOsWtg5Fj6v0c9K930bVfNwmgzF0yLRsZ/xD0OK6t+8UX9O5SZShpHYkk/gWovcA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.29.0"
 
 eslint-scope@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
BREAKING CHANGE: Current `@testing-library/react` usage may need updated to satisfy the new
rules introduced in this version.