### PR TITLE
feat(rules): disable @typescript-eslint/explicit-function-return-type

### DIFF
--- a/lib/config/rules/typescript.js
+++ b/lib/config/rules/typescript.js
@@ -10,13 +10,7 @@ module.exports = {
     },
   ],
   '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-  '@typescript-eslint/explicit-function-return-type': [
-    'error',
-    {
-      // TODO: how annoying would it be to drop this...
-      allowExpressions: true,
-    },
-  ],
+  '@typescript-eslint/explicit-function-return-type': 'off',
   '@typescript-eslint/explicit-module-boundary-types': 'error',
   '@typescript-eslint/interface-name-prefix': 'error',
   '@typescript-eslint/no-empty-interface': 'error',


### PR DESCRIPTION
The most important thing is enforcing explicit function return types on exported functions.
That scenario is covered by @typescript-eslint/explicit-module-boundary-types, so this rule
can be disabled to allow TypeScript to infer return types of internal functions (which can
still be declared explicitly if needed), which should provide a smoother developer experience.