### PR TITLE
feat(jest-dom): move to plugin:wkovacs64/jest-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Next, you may augment the core configuration by applying any combination of
 | Feature    | Extends                         |
 | ---------- | ------------------------------- |
 | Jest       | `'plugin:wkovacs64/jest'`       |
+| jest-dom   | `'plugin:wkovacs64/jest-dom'`   |
 | TypeScript | `'plugin:wkovacs64/typescript'` |
 
 #### Prettier Configs
@@ -61,13 +62,14 @@ module.exports = {
 };
 ```
 
-React project with Jest and Prettier:
+React project with Jest, jest-dom, and Prettier:
 
 ```js
 module.exports = {
   extends: [
     'plugin:wkovacs64/react',
     'plugin:wkovacs64/jest',
+    'plugin:wkovacs64/jest-dom',
     'prettier',
     'prettier/react',
   ],
@@ -88,13 +90,14 @@ module.exports = {
 };
 ```
 
-React project with Jest, TypeScript, and Prettier:
+React project with Jest, jest-dom, TypeScript, and Prettier:
 
 ```js
 module.exports = {
   extends: [
     'plugin:wkovacs64/react',
     'plugin:wkovacs64/jest',
+    'plugin:wkovacs64/jest-dom',
     'plugin:wkovacs64/typescript',
     'prettier',
     'prettier/react',

--- a/lib/config/jest-dom.js
+++ b/lib/config/jest-dom.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: ['jest-dom'],
+
+  rules: require('./rules/jest-dom'),
+};

--- a/lib/config/jest.js
+++ b/lib/config/jest.js
@@ -1,11 +1,9 @@
-const merge = require('merge');
-
 module.exports = {
   env: {
     'jest/globals': true,
   },
 
-  plugins: ['jest', 'jest-dom'],
+  plugins: ['jest'],
 
-  rules: merge(require('./rules/jest'), require('./rules/jest-dom')),
+  rules: require('./rules/jest'),
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ module.exports = {
     // Feature configs - when extending, these go after the core config
     typescript: require('./config/typescript'),
     jest: require('./config/jest'),
+    'jest-dom': require('./config/jest-dom'),
 
     // Prettier config - when extending, this must go last
     // prettier: require('./config/prettier'),


### PR DESCRIPTION
Originally, `jest-dom` was baked into the `plugin:wkovacs64/jest`, but this is incorrect, as
one might be using Jest in a project that has nothing to do with the DOM.