### PR TITLE
feat(testing-library): move to plugin:wkovacs64/testing-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ configurations (described below) in your `extends` array.
 Next, you may augment the core configuration by applying any combination of
 "feature" configs.
 
-| Feature    | Extends                         |
-| ---------- | ------------------------------- |
-| Jest       | `'plugin:wkovacs64/jest'`       |
-| jest-dom   | `'plugin:wkovacs64/jest-dom'`   |
-| TypeScript | `'plugin:wkovacs64/typescript'` |
+| Feature         | Extends                              |
+| --------------- | ------------------------------------ |
+| Jest            | `'plugin:wkovacs64/jest'`            |
+| jest-dom        | `'plugin:wkovacs64/jest-dom'`        |
+| Testing Library | `'plugin:wkovacs64/testing-library'` |
+| TypeScript      | `'plugin:wkovacs64/typescript'`      |
 
 #### Prettier Configs
 
@@ -62,7 +63,7 @@ module.exports = {
 };
 ```
 
-React project with Jest, jest-dom, and Prettier:
+React project with Jest, jest-dom, Testing Library, and Prettier:
 
 ```js
 module.exports = {
@@ -70,6 +71,7 @@ module.exports = {
     'plugin:wkovacs64/react',
     'plugin:wkovacs64/jest',
     'plugin:wkovacs64/jest-dom',
+    'plugin:wkovacs64/testing-library',
     'prettier',
     'prettier/react',
   ],
@@ -90,7 +92,7 @@ module.exports = {
 };
 ```
 
-React project with Jest, jest-dom, TypeScript, and Prettier:
+React project with Jest, jest-dom, Testing Library, TypeScript, and Prettier:
 
 ```js
 module.exports = {
@@ -98,6 +100,7 @@ module.exports = {
     'plugin:wkovacs64/react',
     'plugin:wkovacs64/jest',
     'plugin:wkovacs64/jest-dom',
+    'plugin:wkovacs64/testing-library',
     'plugin:wkovacs64/typescript',
     'prettier',
     'prettier/react',

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -7,14 +7,11 @@ module.exports = {
     browser: true,
   },
 
-  plugins: ['testing-library'],
-
   rules: merge(
     require('./rules/eslint'),
     require('./rules/import'),
     require('./rules/jsx-a11y'),
     require('./rules/react-hooks'),
     require('./rules/react'),
-    require('./rules/testing-library'),
   ),
 };

--- a/lib/config/testing-library.js
+++ b/lib/config/testing-library.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: ['testing-library'],
+
+  rules: require('./rules/testing-library'),
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,10 @@ module.exports = {
     react: require('./config/react'),
 
     // Feature configs - when extending, these go after the core config
-    typescript: require('./config/typescript'),
     jest: require('./config/jest'),
     'jest-dom': require('./config/jest-dom'),
+    'testing-library': require('./config/testing-library'),
+    typescript: require('./config/typescript'),
 
     // Prettier config - when extending, this must go last
     // prettier: require('./config/prettier'),


### PR DESCRIPTION
Originally, `testing-library` was baked into `plugin:wkovacs64/react`, but this is incorrect,
as one might be using Cypress Testing Library (for example) in a project that does not use
React Testing Library.