### PR TITLE
feat(testing-library): enable `prefer-find-by` rule

### DIFF
--- a/lib/config/rules/testing-library.js
+++ b/lib/config/rules/testing-library.js
@@ -9,6 +9,7 @@ module.exports = {
   'testing-library/no-manual-cleanup': 'error',
   'testing-library/no-wait-for-empty-callback': 'error',
   'testing-library/prefer-explicit-assert': 'error',
+  'testing-library/prefer-find-by': 'error',
   'testing-library/prefer-presence-queries': 'error',
   'testing-library/prefer-screen-queries': 'error',
   'testing-library/prefer-wait-for': 'error',


### PR DESCRIPTION
Suggest using `findBy*` methods instead of the `waitFor` + `getBy` queries.

BREAKING CHANGE: You may need to run `eslint --fix` if you were violating this rule.