### PR TITLE
feat: drop support for eslint v5 and v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "typescript": "3.9.5"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0 || ^6.1.0 || ^7.3.1"
+    "eslint": "^7.3.1"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This plugin now requires eslint v7.